### PR TITLE
Fix typo when displaying help information

### DIFF
--- a/bin/g
+++ b/bin/g
@@ -85,7 +85,7 @@ display_help() {
     -q, --quiet             Disable curl output (if available)
     -d, --download          Download only
     -c, --no-color          Force disabled color output
-    -i, --non-interactive   Prevent promtps
+    -i, --non-interactive   Prevent prompts
     -o, --os                Override operating system
     -a, --arch              Override system architecture
 


### PR DESCRIPTION
As requested in #1, this PR fixes a typo found when rendering help information with the `--help` flag