### PR TITLE
Add Current and Load command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 
+## 0.9.0 - 2020-05-11
+
+- Change shebang to /usr/bin/env sh because it will search sh from the user $PATH
+- Add current command to show current go version simply
+- Add load command to set go version for given project directory based on go.mod file
+
 ## 0.8.0 - 2019-12-24
 
 - Fix arch detection bug in MacOS with coreutils (#15, thanks @ddlees)

--- a/README.md
+++ b/README.md
@@ -144,11 +144,13 @@ curl -sSL https://git.io/g-install | sh -s
   Commands:
 
     g                         Open interactive UI with downloaded versions
+    g current                 Output current version
     g install latest          Download and set the latest go release
     g install <version>       Download and set go <version>
     g download <version>      Download go <version>
     g set <version>           Switch to go <version>
     g run <version>           Run a given version of go
+    g load <project dir>      Set to <project dir> go version
     g which <version>         Output bin path for <version>
     g remove <version ...>    Remove the given version(s)
     g prune                   Remove all versions except the current version
@@ -239,7 +241,7 @@ At this point you would have removed `g` and `go` entirely.
 - [x] Make the `self-upgrade` command throw if `g` was not installed in the common way
 - [ ] Add a `complete` command that generates completions for the supported shells
     - [ ] And have `g-install` setup the shells to call this command for completions
-- [ ] Explore feature to configure shells to autoload go versions based on a project file
+- [x] Explore feature to configure shells to autoload go versions based on a project file
 - [ ] Test it on diff platforms
 - [ ] Crete a test setup with docker and Github actions
 

--- a/bin/g
+++ b/bin/g
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env sh
 
 # MIT License
 #
@@ -63,7 +63,7 @@ esac
 #
 
 display_g_version() {
-  echo "0.8.0"
+  echo "0.9.0"
 }
 
 display_help() {
@@ -74,11 +74,13 @@ display_help() {
   Commands:
 
     g                         Open interactive UI with downloaded versions
+    g current                 Output current version
     g install latest          Download and set the latest go release
     g install <version>       Download and set go <version>
     g download <version>      Download go <version>
     g set <version>           Switch to go <version>
     g run <version>           Run a given version of go
+    g load <project dir>      Set to <project dir> go version
     g which <version>         Output bin path for <version>
     g remove <version ...>    Remove the given version(s)
     g prune                   Remove all versions except the current version
@@ -771,6 +773,32 @@ self_upgrade() {
 }
 
 #
+# Autoload go version for the given <projectDir>
+#
+
+load_project_version() {
+  if [ ! -d "$1" ]; then
+     error_and_abort "directory $1 not found"
+  fi
+
+  if [ "$1" != */ ]; then
+    cleanPath="$1/"
+  fi
+
+  goMod="${cleanPath}go.mod"
+
+  if [ ! -f "$goMod" ]; then
+    error_and_abort "file $goMod not found"
+  fi
+
+  goVersion=$(grep "^go [0-9\.]*" $goMod | sed -e "s/go //" )
+
+  log_info "selected" "go $goVersion"
+
+  set_version $goVersion
+}
+
+#
 # Make sure required go env vars are available.
 #
 
@@ -818,7 +846,7 @@ if [ $# -eq 0 ]; then
 else
   while test $# -ne 0; do
     case $1 in
-      install | set | download | run | remove | prune | which | list | list-all | self-upgrade) __cmd=$1 ;;
+      current | install | set | download | run | load | remove | prune | which | list | list-all | self-upgrade) __cmd=$1 ;;
       -h | --help | help)
         display_help
         exit
@@ -851,10 +879,12 @@ else
   # The unquoted expansions here are intentional.
   # shellcheck disable=SC2086
   case $__cmd in
+    current) get_current_version ;;
     install) install_version $__cmd_args ;;
     download) download_version $__cmd_args ;;
     set) set_version $__cmd_args ;;
     run) run_with_version $__cmd_args ;;
+    load) load_project_version $__cmd_args;;
     remove) remove_versions $__cmd_args ;;
     prune) prune_versions ;;
     which) display_bin_path_for_version $__cmd_args ;;


### PR DESCRIPTION
- Change shebang to /usr/bin/env sh because it will search sh from the user $PATH
- Add current command to show current go version simply
- Add load command to set go version for given project directory based on go.mod file