### PR TITLE
perf: symlink instead of copy all items from specific version to GOROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve performance of switching between different Go versions to nearly instant
 
 ## 0.8.1 - 2021-03-17
 

--- a/bin/g
+++ b/bin/g
@@ -588,11 +588,18 @@ set_version() {
   if [ "$version" != "$active" ]; then
     if [ ! -e "$dir/g.lock" ]; then
       for file in "$dir/"*; do
-        rm -rf "${GOROOT:?}/$(basename "$file")"
-        cp -Rf "$file" "$GOROOT/$(basename "$file")"
+        if [ -L "${GOROOT:?}/$(basename "$file")" ]; then
+          rm "${GOROOT:?}/$(basename "$file")"
+        elif [ -e "${GOROOT:?}/$(basename "$file")" ]; then
+          # enable seamless upgrade to symlink behavior
+          rm -rf "${GOROOT:?}/$(basename "$file")"
+        fi
+        ln -sf "$file" "${GOROOT:?}/$(basename "$file")"
       done
 
-      ln -sf "$GOROOT/bin/"* "$GOPATH/bin/"
+      for file in "$dir/bin/"*; do
+        ln -sf "$GOROOT/bin/$(basename "$file")" "$GOPATH/bin/"
+      done
     else
       error_and_abort "version $version installation might be corrupted"
     fi


### PR DESCRIPTION
The gaols here are:

- Make `g set <version>` much faster, as it no longer needs to delete
  and copy around 400MB / 10,000 files. Instead it just updates 20
  symlinks.
- Avoid the need to execute `rm -rf ...` as that always makes me
  nervous. The old `rm -rf ...` command is still present in the event
  that the target file/folder for the new symlink is a file or folder
  instead of a symlink. This is required to enable a seamless upgrade
  from the old method of populating GOROOT.

A for loop was needed to iterate over the each binary in the source
version's `bin` folder, as `$GOROOT/bin` is now a symlink, the old
`"$GOROOT/bin/"*` expansion no longer worked correctly.

---

Apologies if this kind of behavior/change has been discussed in the past, I've had a poke around issues and PRs, but couldn't spot anything. Hopefully I'm not blind :)

I should mention that I've only tested this on macOS (Big Sur) for now, but I'm happy to test it on Linux too.