### PR TITLE
Use go env as fallback for GOPATH and GOROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Use `go env` as fallback for `GOPATH` and `GOROOT`
 
 ## 0.9.0 - 2021-03-19
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ curl -sSL https://git.io/g-install | sh -s
 
 ## Manual Installation
 
-1. Make sure to export the `$GOPATH` & `$GOROOT` environment variables and add `$GOPATH/bin` to your `PATH`.
+1. Make sure to export the `$GOPATH` & `$GOROOT` environment variables and add `$GOPATH/bin` to your `PATH`. Alternatively, if you already have go installed and want to switch to using `g`, set `GOPATH` and `GOROOT` using `go env -w`.
 2. Grab a copy of the [`./bin/g`](./bin/g) script and put it anywhere available in your `PATH` — inside `$GOPATH/bin/` is a good option.
 3. Give the script execution rights with `chmod +x $GOPATH/bin/g`.
 4. Restart your shell session to make sure the env variables are loaded.

--- a/bin/g
+++ b/bin/g
@@ -778,6 +778,18 @@ self_upgrade() {
 }
 
 #
+# Use go env as fallback for explicitly defined GOPATH and GOROOT
+#
+
+if [ -z "${GOPATH:-}" ] && command -v go > /dev/null; then
+  GOPATH=$(go env GOPATH)
+fi
+
+if [ -z "${GOROOT:-}" ] && command -v go > /dev/null; then
+  GOROOT=$(go env GOROOT)
+fi
+
+#
 # Make sure required go env vars are available.
 #
 


### PR DESCRIPTION
These variables can also be set using `go env -w`.

Fixes #24 