### PR TITLE
Fix the grep warning: stray \ before "

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 
 ## 0.9.0 - 2021-03-19
+- Fix the grep warning: stray \ before " with the latest releases of grep
 
 - Improve switching Go versions performance to nearly instant (#19, thanks @jimeh)
 - Add support for darwin-arm64 (M1 chips) (#20, thanks @joelanford)

--- a/bin/g
+++ b/bin/g
@@ -346,7 +346,7 @@ get_all_remote_versions() {
   fi
 
   download_file 2> /dev/null "https://go.googlesource.com/go/+refs" \
-    | grep -E -o '\"/go/\+/refs/tags/go.+?\"' \
+    | grep -E -o '"/go/\+/refs/tags/go.+?"' \
     | grep -E -o "$pattern" \
     | tr -d 'go' \
     | sort -k 1,1n -k 2,2n -k 3,3n -t . \


### PR DESCRIPTION
When executing `g` on systems with newer versions of `grep`, two warnings are raised.

![image](https://user-images.githubusercontent.com/33818/194012985-a940ab93-cd3c-454e-928a-91bd0bde590a.png)

This pull request fixes the `grep` warning, removing the escaping of the double quotes when the pattern is enclosed in single quotes.

Tested on Arch Linux with `grep 3.8` and on MacOS with `grep 2.6.0`.