### PR TITLE
Add "use" as an alias for "set"

### DIFF
--- a/bin/g
+++ b/bin/g
@@ -828,7 +828,7 @@ if [ $# -eq 0 ]; then
 else
   while test $# -ne 0; do
     case $1 in
-      install | set | download | run | remove | prune | which | list | list-all | self-upgrade) __cmd=$1 ;;
+      install | set | use | download | run | remove | prune | which | list | list-all | self-upgrade) __cmd=$1 ;;
       -h | --help | help)
         display_help
         exit
@@ -863,7 +863,7 @@ else
   case $__cmd in
     install) install_version $__cmd_args ;;
     download) download_version $__cmd_args ;;
-    set) set_version $__cmd_args ;;
+    set | use) set_version $__cmd_args ;;
     run) run_with_version $__cmd_args ;;
     remove) remove_versions $__cmd_args ;;
     prune) prune_versions ;;


### PR DESCRIPTION
I find myself trying to `g use <version>` every time I come back to this tool only to get an error. So I am suggeting this alias.

I have skipped adding documentation for this alias because I'm not sure what that should look like.
The `n` tool has aliases and documents them in a
separate list from the non-aliased commands. But
no prior aliases exist here.